### PR TITLE
Support for merged cells and hyperlinks in Excel template

### DIFF
--- a/tbs_plugin_opentbs.php
+++ b/tbs_plugin_opentbs.php
@@ -151,7 +151,7 @@ class clsOpenTBS extends clsTbsZip {
 		$this->DebugLst = false; // deactivate the debug mode
 		$this->ExtInfo = false;
 		$TBS->TbsZip = &$this; // a shortcut
-		$this->MrgCells = array();
+		$this->mergeCells = array();
 		return array('BeforeLoadTemplate','BeforeShow', 'OnCommand', 'OnOperation', 'OnCacheField');
 	}
 
@@ -236,7 +236,7 @@ class clsOpenTBS extends clsTbsZip {
 		if ($this->TbsSystemCredits) {
 			$this->Misc_EditCredits("OpenTBS " . $this->Version, true, true);
 		}
-		
+
 		$this->TbsStorePark(); // Save the current loaded subfile if any
 
 		$TBS->Plugin(-4); // deactivate other plugins
@@ -375,14 +375,13 @@ class clsOpenTBS extends clsTbsZip {
 		} elseif ($ope==='docfield') {
 			$this->TbsDocFieldPrepare($Txt, $Loc);
 		} elseif ($ope==='mergecells') {
-			list($colSpan, $rowSpan) = explode(':', isset($PrmLst['merge']) ? $PrmLst['merge'] : $Value);
-			$colSpan = intval($colSpan);
-			$rowSpan = intval($rowSpan);
+			$rowSpan = intval(isset($PrmLst['rows']) ? $PrmLst['rows'] : $Value);
+			$colSpan = intval(isset($PrmLst['cols']) ? $PrmLst['cols'] : $Value);
 			if ($colSpan >= 1 && $rowSpan >= 1) {
 				list($cellCol, $cellRow) = $this->Sheet_CellPosition($Txt, $PosBeg);
 				$startCell = $this->Sheet_CellRef($cellCol, $cellRow);
 				$endCell = $this->Sheet_CellRef($cellCol + $colSpan - 1, $cellRow + $rowSpan - 1);
-				$this->MrgCells[$startCell] = "$startCell:$endCell";
+				$this->mergeCells[$startCell] = "$startCell:$endCell";
 				$Value = '';
 			}
 		} else {
@@ -587,7 +586,7 @@ class clsOpenTBS extends clsTbsZip {
 				$o = $this->MsExcel_SheetGetConf($x1, $SearchBy, true);
 				if ($o===false) return false;
 				if ($o->file===false) return $this->RaiseError("($Cmd) Error with sheet '$x1'. The corresponding XML subfile is not referenced.");
-				$this->MrgCells = array();
+				$this->mergeCells = array();
 				return $this->TbsLoadSubFileAsTemplate('xl/'.$o->file);
 			}
 			

--- a/tbs_plugin_opentbs.php
+++ b/tbs_plugin_opentbs.php
@@ -336,6 +336,7 @@ class clsOpenTBS extends clsTbsZip {
 	}
 
 	function MsExcel_WriteListOfMergeCells() {
+		$this->mergeCells = array_unique($this->mergeCells);
 		$count = count($this->mergeCells);
 		$mergeCells = '';
 		foreach ($this->mergeCells as $range) {
@@ -475,7 +476,7 @@ class clsOpenTBS extends clsTbsZip {
 				list($cellCol, $cellRow) = $this->Sheet_CellPosition($Txt, $PosBeg);
 				$startCell = $this->Sheet_CellRef($cellCol, $cellRow);
 				$endCell = $this->Sheet_CellRef($cellCol + $colSpan - 1, $cellRow + $rowSpan - 1);
-				$this->mergeCells[$startCell] = "$startCell:$endCell";
+				$this->mergeCells[] = "$startCell:$endCell";
 				$Value = '';
 			}
 		} else {
@@ -4780,8 +4781,7 @@ If they are blank spaces, line beaks, or other unexpected characters, then you h
 		$p = clsTinyButStrong::f_Xml_FindTagStart($Txt, 'mergeCells', true, 0, true, true);
 		if ($p === false) return;
 		while ($loc=clsTinyButStrong::f_Xml_FindTag($Txt, 'mergeCell', true, $p, true, false, true, true) ) {
-			list($startCell) = explode(':', $loc->PrmLst['ref']);
-			$this->mergeCells[$startCell] = $loc->PrmLst['ref'];
+			$this->mergeCells[] = $loc->PrmLst['ref'];
 			$p = $loc->PosEnd;
 		}
 	}

--- a/tbs_plugin_opentbs.php
+++ b/tbs_plugin_opentbs.php
@@ -492,18 +492,29 @@ class clsOpenTBS extends clsTbsZip {
 		}
 	}
 
-	function Sheet_CellPosition($Txt, $PosBeg) {
+	function Sheet_CellPosition($Txt, $PosBeg, $RowEl = null, $CellEl = null) {
+		if ($RowEl === null && $CellEl === null) {
+			switch ($this->ExtEquiv) {
+				case 'xlsx':
+					return $this->Sheet_CellPosition($Txt, $PosBeg, 'row', 'c');
+				case 'ods':
+					$this->OpenDoc_CoveredCells_Replace($Txt, true);
+					return $this->Sheet_CellPosition($Txt, $PosBeg, 'table:table-row', 'table:table-cell');
+				default:
+					return [null, null];
+			}
+		}
 		$lastPos = 0;
 		$cellRow = 0;
 		do {
-			$p = clsTinyButStrong::f_Xml_FindTagStart($Txt, 'row', true, $lastPos+1, true, true);
+			$p = clsTinyButStrong::f_Xml_FindTagStart($Txt, $RowEl, true, $lastPos+1, true, true);
 			if ($p === false || $p >= $PosBeg) break;
 			$lastPos = $p;
 			$cellRow++;
 		} while(true);
 		$cellCol = 0;
 		do {
-			$p = clsTinyButStrong::f_Xml_FindTagStart($Txt, 'c', true, $lastPos+1, true, true);
+			$p = clsTinyButStrong::f_Xml_FindTagStart($Txt, $CellEl, true, $lastPos+1, true, true);
 			if ($p === false || $p >= $PosBeg) break;
 			$lastPos = $p;
 			$cellCol++;


### PR DESCRIPTION
Hyperlinks in Excel template are recorded in <hyperlinks> element. This PR adds support for keeping <hyperlinks> updated correctly when rows/cells are added as a result of the calls to `MergeBlock`.

Merged cells in Excel template are records in <mergeCells> element. This PR adds similar support for <mergeCells> element.

This kind of support only works for merged cells and hyperlinks that are not in the same row as the row that has `block=tbs:row` (and similarly, not in the same column as the column that has`block=tbs:cell`).

A new ope was introduced to support this case, that's `ope=mergecells`.

Example:
- in a row that has `block=tbs:row`, a cell with `ope=mergecells;cols=2`  would generate a merged cell (containing 2 columns) in each added row
- in a row that has `block=tbs:cell`, a cell with `ope=mergecells;rows=3`  would generate a merged cell (containing 3 rows) in each added column

Parameters `rows` and `cols` can be omitted. The default value is the value of the current field. This feature allows the dimensions of the merged cell to be determined dynamically.

Example:
- in a row that has `block=tbs:row`, a cell with `[block1.field2;ope=mergecells;rows=1]` and  `block1.field2` has value 4 would generate a merged cell (containing 4 columns) in each added row
- in a row that has `block=tbs:cell`, a cell with `[block1.field2;ope=mergecells;cols=1]`  and  `block1.field2` has value 5 would generate a merged cell (containing 5 rows) in each added column